### PR TITLE
Update to recent distros and collate install steps

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,89 +29,40 @@ else
   QA_VAGRANT_LIBVIRT_INSTALL_OPTS = "vagrant-libvirt --plugin-version #{QA_VAGRANT_LIBVIRT_VERSION}"
 end
 
-# Some boilerplate to allow local shell commands on host
-module LocalCommand
-    class Config < Vagrant.plugin("2", :config)
-        attr_accessor :command
-    end
-
-    class Plugin < Vagrant.plugin("2")
-        name "local_shell"
-
-        config(:local_shell, :provisioner) do
-            Config
-        end
-
-        provisioner(:local_shell) do
-            Provisioner
-        end
-    end
-
-    class Provisioner < Vagrant.plugin("2", :provisioner)
-        def provision
-            result = system "#{config.command}"
-        end
-    end
-end
-
-# some common commands
-WGET_VAGRANT_DEB = "wget --no-check-certificate --no-verbose https://releases.hashicorp.com/vagrant/#{QA_VAGRANT_VERSION}/vagrant_#{QA_VAGRANT_VERSION}_x86_64.deb"
-WGET_VAGRANT_RPM = "wget --no-check-certificate --no-verbose https://releases.hashicorp.com/vagrant/#{QA_VAGRANT_VERSION}/vagrant_#{QA_VAGRANT_VERSION}_x86_64.rpm"
-
-APT_UPDATE = 'DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get update'
-APT_DIST_UPGRADE = 'DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get -y -o Dpkg::Options::="--force-confold" dist-upgrade'
-APT_GET_RUBY_LIBVIRT = 'DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get -y build-dep vagrant ruby-libvirt'
-
-UBUNTU_GET_DEPS = 'DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get -y -o Dpkg::Options::="--force-confold" install qemu libvirt-bin wget git'
-DEBIAN_GET_DEPS = 'DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get -y -o Dpkg::Options::="--force-confold" install qemu libvirt-clients libvirt-daemon libvirt-daemon-system wget ebtables dnsmasq git'
-
-DPKG_INSTALL_VAGRANT = "DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true dpkg -i vagrant_#{QA_VAGRANT_VERSION}_x86_64.deb"
-
-BUILD_FROM_GIT = 'git clone https://github.com/vagrant-libvirt/vagrant-libvirt.git && cd vagrant-libvirt && gem build vagrant-libvirt.gemspec'
-INSTALL_PLUGIN = "vagrant plugin install #{QA_VAGRANT_LIBVIRT_INSTALL_OPTS}"
-INFERNIX_VAGRANTFILE = <<-EOC
-cat <<-'EOF' > Vagrantfile
-ENV['VAGRANT_DEFAULT_PROVIDER'] = 'libvirt'
-Vagrant.configure(2) do |config|
-  config.vm.define "tiny" do |v|
-    v.vm.box = "infernix/tinycore"
-    v.vm.synced_folder ".", "/vagrant", disabled: true
-    v.vm.provider :libvirt do |domain|
-      domain.management_network_address = '172.31.254.0/24'
-      domain.memory = 64
-      domain.cpus = 1
-      domain.cpu_mode = 'host-passthrough'
-    end
-    v.ssh.insert_key = false
-  end
-end
-EOF
-EOC
-PATCH_VAGRANT_CORE_LINUX = 'for i in /opt/vagrant/embedded/gems/gems/vagrant-*/plugins/guests/tinycore/guest.rb; do sed -i "s/Core Linux/Core.*Linux/" $i; done'
-VAGRANT_DESTROY = 'vagrant destroy -f 2>/dev/null 1>/dev/null;vagrant up --provider=libvirt && vagrant halt'
+APT_ENV_VARS = {
+  'DEBIAN_FRONTEND': 'noninteractive',
+  'DEBCONF_NONINTERACTIVE_SEEN': true,
+}
 
 def setup_vm_provider(vm)
   vm.provider :libvirt do |domain|
     domain.driver = 'kvm'
-    domain.memory = 1024
-    domain.cpus = 1
+    domain.memory = 2048
+    domain.cpus = 2
     domain.nested = true
     domain.cpu_mode = 'host-passthrough'
   end
 end
 
 def add_test_provisions(vm)
-  if QA_VAGRANT_LIBVIRT_VERSION == "master"
-    vm.provision :shell, :inline => BUILD_FROM_GIT
-  end
-  vm.provision :shell, :inline => INSTALL_PLUGIN
   # Workarond for Vagrant bug
-  if QA_VAGRANT_VERSION == "1.8.7" || QA_VAGRANT_VERSION == "1.9.0" || QA_VAGRANT_VERSION == "1.9.1"
-    vm.provision :shell, :inline => PATCH_VAGRANT_CORE_LINUX
+  if Gem::Version.new(QA_VAGRANT_VERSION) < Gem::Version.new('1.9.1')
+    vm.provision :shell, :inline => <<-EOC
+    for i in /opt/vagrant/embedded/gems/gems/vagrant-*/plugins/guests/tinycore/guest.rb
+    do
+      sed -i "s/Core Linux/Core.*Linux/" $i
+    done
+    EOC
   end
   # Testing nested VM provisioning via nested kvm
-  vm.provision :shell, :inline => INFERNIX_VAGRANTFILE
-  vm.provision :shell, :inline => VAGRANT_DESTROY
+  vm.provision :file, :source => './Vagrantfile.test', :destination => '~/Vagrantfile'
+  vm.provision :shell, :privileged => false, :inline => <<-EOC
+    set -e
+    vagrant destroy -f 2>/dev/null 1>/dev/null
+    vagrant up --provider=libvirt
+    vagrant halt
+    vagrant destroy -f
+  EOC
 end
 
 Vagrant.configure(2) do |config|
@@ -121,39 +72,33 @@ Vagrant.configure(2) do |config|
     v.vm.box = "generic/ubuntu1804"
     v.vm.synced_folder ".", "/vagrant", disabled: true
     setup_vm_provider(v.vm)
-    v.vm.provision :shell, :inline => 'sed -i "s/# deb-src/deb-src/" /etc/apt/sources.list'
-    v.vm.provision :shell, :inline => APT_UPDATE
-    v.vm.provision :shell, :inline => APT_DIST_UPGRADE
-    v.vm.provision :shell, :inline => APT_GET_RUBY_LIBVIRT
-    v.vm.provision :shell, :inline => UBUNTU_GET_DEPS
-    v.vm.provision :reload
-    v.vm.provision :shell, :inline => WGET_VAGRANT_DEB
-    v.vm.provision :shell, :inline => DPKG_INSTALL_VAGRANT
+    v.vm.provision :shell, :inline => 'ln -sf ../run/systemd/resolve/resolv.conf /etc/resolv.conf'
+    v.vm.provision :shell, :privileged => false, :path => './scripts/install.bash', :args => QA_VAGRANT_VERSION
+    v.vm.provision :shell, :reset => true, :inline => 'usermod -a -G libvirt vagrant'
     add_test_provisions(v.vm)
   end
 
-  config.vm.define "debian-9" do |v|
-    v.vm.hostname = "debian-9"
-    v.vm.box = "debian/stretch64"
+  config.vm.define "ubuntu-20.04" do |v|
+    v.vm.hostname = "ubuntu-20.04"
+    v.vm.box = "generic/ubuntu2004"
     v.vm.synced_folder ".", "/vagrant", disabled: true
     setup_vm_provider(v.vm)
-    v.vm.provision :shell, inline: <<-EOC
-cat <<-'EOF' >/etc/apt/sources.list
- deb http://httpredir.debian.org/debian stretch main contrib non-free
- deb-src http://httpredir.debian.org/debian stretch main contrib non-free
- deb http://security.debian.org/ stretch/updates main contrib non-free
- deb-src http://security.debian.org/ stretch/updates main contrib non-free
- deb http://httpredir.debian.org/debian stretch-updates main contrib non-free
- deb-src http://httpredir.debian.org/debian stretch-updates main contrib non-free
-EOF
-EOC
-    v.vm.provision :shell, :inline => APT_UPDATE
-    v.vm.provision :shell, :inline => APT_DIST_UPGRADE
-    v.vm.provision :shell, :inline => APT_GET_RUBY_LIBVIRT
-    v.vm.provision :shell, :inline => DEBIAN_GET_DEPS
-    v.vm.provision :reload
-    v.vm.provision :shell, :inline => WGET_VAGRANT_DEB
-    v.vm.provision :shell, :inline => DPKG_INSTALL_VAGRANT
+    v.vm.provision :shell, :inline => 'ln -sf ../run/systemd/resolve/resolv.conf /etc/resolv.conf'
+    v.vm.provision :shell, :privileged => false, :path => './scripts/install.bash', :args => QA_VAGRANT_VERSION
+    v.vm.provision :shell, :reset => true, :inline => 'usermod -a -G libvirt vagrant'
+    add_test_provisions(v.vm)
+  end
+
+  config.vm.define "debian-10" do |v|
+    v.vm.hostname = "debian-10"
+    v.vm.box = "generic/debian10"
+    v.vm.synced_folder ".", "/vagrant", disabled: true
+    setup_vm_provider(v.vm)
+    v.vm.provision :shell, :inline => 'sed -i -e "/^dns-nameserver/g" /etc/network/interfaces', :reboot => true
+    # restarting dnsmasq can require a retry after everything else to come up correctly.
+    v.vm.provision :shell, :inline => 'apt update && apt install -y dnsmasq && systemctl restart dnsmasq', :env => APT_ENV_VARS
+    v.vm.provision :shell, :privileged => false, :path => './scripts/install.bash', :args => QA_VAGRANT_VERSION
+    v.vm.provision :shell, :reset => true, :inline => 'usermod -a -G libvirt vagrant'
     add_test_provisions(v.vm)
   end
 
@@ -162,24 +107,38 @@ EOC
     v.vm.box = "centos/7"
     v.vm.synced_folder ".", "/vagrant", disabled: true
     setup_vm_provider(v.vm)
-    v.vm.provision :shell, :inline => 'yum -y update'
-    v.vm.provision :shell, :inline => 'yum -y install qemu libvirt libvirt-devel ruby-devel wget gcc qemu-kvm git'
-    v.vm.provision :reload
-    v.vm.provision :shell, :inline => WGET_VAGRANT_RPM
-    v.vm.provision :shell, :inline => "rpm -Uvh --force vagrant_#{QA_VAGRANT_VERSION}_x86_64.rpm | sed 's/#//g'"
+    v.vm.provision :shell, :privileged => false, :path => './scripts/install.bash', :args => QA_VAGRANT_VERSION
+    v.vm.provision :shell, :reset => true, :inline => 'usermod -a -G libvirt vagrant'
     add_test_provisions(v.vm)
   end
 
-  config.vm.define "fedora-29" do |v|
-    v.vm.hostname = "fedora-29"
-    v.vm.box = "fedora/29-cloud-base"
+  config.vm.define "centos-8" do |v|
+    v.vm.hostname = "centos-8"
+    v.vm.box = "centos/8"
     v.vm.synced_folder ".", "/vagrant", disabled: true
     setup_vm_provider(v.vm)
-    v.vm.provision :shell, :inline => 'dnf -y update'
-    v.vm.provision :shell, :inline => 'dnf -y install qemu libvirt libvirt-devel ruby-devel wget make gcc binutils autoconf automake git'
-    v.vm.provision :reload
-    v.vm.provision :shell, :inline => WGET_VAGRANT_RPM
-    v.vm.provision :shell, :inline => "rpm -Uvh --force vagrant_#{QA_VAGRANT_VERSION}_x86_64.rpm | sed 's/#//g'"
+    v.vm.provision :shell, :privileged => false, :path => './scripts/install.bash', :args => QA_VAGRANT_VERSION
+    v.vm.provision :shell, :reset => true, :inline => 'usermod -a -G libvirt vagrant'
+    add_test_provisions(v.vm)
+  end
+
+  config.vm.define "fedora-33" do |v|
+    v.vm.hostname = "fedora-33"
+    v.vm.box = "generic/fedora33"
+    v.vm.synced_folder ".", "/vagrant", disabled: true
+    setup_vm_provider(v.vm)
+    v.vm.provision :shell, :privileged => false, :path => './scripts/install.bash', :args => QA_VAGRANT_VERSION
+    v.vm.provision :shell, :reset => true, :inline => 'usermod -a -G libvirt vagrant'
+    add_test_provisions(v.vm)
+  end
+
+  config.vm.define "fedora-34" do |v|
+    v.vm.hostname = "fedora-34"
+    v.vm.box = "generic/fedora34"
+    v.vm.synced_folder ".", "/vagrant", disabled: true
+    setup_vm_provider(v.vm)
+    v.vm.provision :shell, :privileged => false, :path => './scripts/install.bash', :args => QA_VAGRANT_VERSION
+    v.vm.provision :shell, :reset => true, :inline => 'usermod -a -G libvirt vagrant'
     add_test_provisions(v.vm)
   end
 
@@ -188,11 +147,8 @@ EOC
     v.vm.box = "archlinux/archlinux"
     v.vm.synced_folder ".", "/vagrant", disabled: true
     setup_vm_provider(v.vm)
-    v.vm.provision :shell, :inline => 'pacman -Suyu --noconfirm --noprogressbar'
-    v.vm.provision :shell, :inline => 'pacman -S --noconfirm --noprogressbar vagrant git ruby make gcc binutils autoconf automake libxml2 libxslt pkg-config libvirt qemu openbsd-netcat bridge-utils ebtables iptables dnsmasq firewalld'
-    v.vm.provision :shell, :inline => 'systemctl enable libvirtd; systemctl start libvirtd; systemctl enable firewalld; systemctl start firewalld'
-    v.vm.provision :shell, :inline => 'usermod -G kvm nobody'
-    v.vm.provision :reload
+    v.vm.provision :shell, :privileged => false, :path => './scripts/install.bash', :args => QA_VAGRANT_VERSION
+    v.vm.provision :shell, :privileged => false, :reset => true, :inline => 'sudo usermod -G kvm $(whoami)'
     add_test_provisions(v.vm)
   end
 end

--- a/Vagrantfile.test
+++ b/Vagrantfile.test
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'libvirt'
+
+Vagrant.configure(2) do |config|
+  config.vm.define "tiny" do |v|
+    v.vm.box = "infernix/tinycore"
+    v.vm.synced_folder ".", "/vagrant", disabled: true
+    v.vm.provider :libvirt do |domain|
+      # attempting to nest here will likely cause issues
+      domain.driver = 'qemu'
+      domain.management_network_address = '172.31.254.0/24'
+      domain.memory = 64
+      domain.cpus = 1
+    end
+    v.ssh.shell = "/bin/sh"
+    v.ssh.insert_key = false
+  end
+end

--- a/scripts/install.bash
+++ b/scripts/install.bash
@@ -1,0 +1,339 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+DPKG_OPTS=(
+    -o Dpkg::Options::="--force-confold"
+)
+VAGRANT_LIBVIRT_VERSION=${VAGRANT_LIBVIRT_VERSION:-"latest"}
+
+function restart_libvirt() {
+    service_name=${1:-libvirtd}
+    # it appears there can be issues with libvirt being started before certain
+    # packages that are required for create behaviour on first run. Restart to
+    # ensure the daemon picks up the latest environment and can create a VM
+    # on the first attempt. Otherwise will need to reboot
+    sudo systemctl restart ${service_name}
+}
+
+function setup_apt() {
+    export DEBIAN_FRONTEND=noninteractive
+    export DEBCONF_NONINTERACTIVE_SEEN=true
+
+    sudo sed -i "s/# deb-src/deb-src/" /etc/apt/sources.list
+    sudo -E apt-get update
+    sudo -E apt-get -y "${DPKG_OPTS[@]}" upgrade
+    sudo -E apt-get -y build-dep vagrant ruby-libvirt
+}
+
+function setup_arch() {
+    sudo pacman -Suyu --noconfirm --noprogressbar
+    sudo pacman -Rd --nodeps --noconfirm iptables
+    # need to remove iptables to allow ebtables to be installed
+    sudo pacman -S --needed --noprogressbar --noconfirm  \
+        autoconf \
+        automake \
+        binutils \
+        bridge-utils \
+        dnsmasq \
+        git \
+        gcc \
+        iptables-nft \
+        libvirt \
+        libxml2 \
+        libxslt \
+        make \
+        openbsd-netcat \
+        pkg-config \
+        qemu \
+        ruby \
+        ;
+    sudo systemctl enable --now libvirtd
+}
+
+function setup_centos_7() {
+    sudo yum -y update
+    sudo yum -y install \
+        autoconf \
+        automake \
+        binutils \
+        cmake \
+        gcc \
+        git \
+        libguestfs-tools \
+        libvirt \
+        libvirt-devel \
+        make \
+        qemu \
+        qemu-kvm \
+        ruby-devel \
+        wget \
+        ;
+    sudo systemctl restart libvirtd
+}
+
+function setup_centos() {
+    sudo dnf -y update
+    sudo dnf -y install \
+        @virt \
+        autoconf \
+        automake \
+        binutils \
+        byacc \
+        cmake \
+        gcc \
+        gcc-c++ \
+        git \
+        make \
+        rpm-build \
+        ruby-devel \
+        wget \
+        zlib-devel \
+        ;
+    sudo systemctl restart libvirtd
+}
+
+function setup_debian() {
+    setup_apt
+    sudo -E apt-get -y "${DPKG_OPTS[@]}" install \
+        dnsmasq \
+        ebtables \
+        git \
+        libvirt-clients \
+        libvirt-daemon \
+        libvirt-daemon-system \
+        qemu \
+        qemu-system-x86 \
+        qemu-utils \
+        wget \
+        ;
+}
+
+function setup_fedora() {
+    sudo dnf -y update
+    sudo dnf -y install \
+        autoconf \
+        automake \
+        binutils \
+        cmake \
+        gcc \
+        git \
+        libguestfs-tools \
+        libvirt \
+        libvirt-daemon-driver-qemu \
+        libvirt-devel \
+        make \
+        qemu-kvm \
+        ruby-devel \
+        wget \
+        ;
+    sudo systemctl restart libvirtd
+}
+
+function setup_ubuntu_1804() {
+    setup_apt
+    sudo -E apt-get -y "${DPKG_OPTS[@]}" install \
+        git \
+        libvirt-bin \
+        qemu \
+        wget \
+        ;
+    restart_libvirt
+}
+
+function setup_ubuntu() {
+    setup_apt
+    sudo -E apt-get -y "${DPKG_OPTS[@]}" install \
+        git \
+        libvirt-clients \
+        libvirt-daemon \
+        libvirt-daemon-system \
+        qemu \
+        qemu-system-x86 \
+        qemu-utils \
+        wget \
+        ;
+}
+
+function setup_distro() {
+    local distro=${1}
+    local version=${2:-}
+
+    if [[ -n "${version}" ]] && [[ $(type -t setup_${distro}_${version} 2>/dev/null) == 'function' ]]
+    then
+        eval setup_${distro}_${version}
+    else
+        eval setup_${distro}
+    fi
+}
+
+
+function download_vagrant() {
+    local version=${1}
+    local pkgext=${2}
+    local pkg="vagrant_${1}_x86_64.${pkgext}"
+
+    wget --no-verbose https://releases.hashicorp.com/vagrant/${version}/${pkg} -O /tmp/${pkg}.tmp
+    mv /tmp/${pkg}.tmp /tmp/${pkg}
+}
+
+function install_vagrant_arch() {
+    sudo pacman -S --needed --noprogressbar --noconfirm  \
+        vagrant
+}
+
+function install_vagrant_centos() {
+    local version=$1
+
+    download_vagrant ${version} rpm
+    sudo -E rpm -Uh --force /tmp/vagrant_${version}_x86_64.rpm
+}
+
+function install_vagrant_debian() {
+    local version=$1
+
+    download_vagrant ${version} deb
+    sudo -E dpkg -i /tmp/vagrant_${version}_x86_64.deb
+}
+
+function install_vagrant_fedora() {
+    install_vagrant_centos $@
+}
+
+function install_vagrant_ubuntu() {
+    install_vagrant_debian $@
+}
+
+function build_libssh() {
+    local dir=${1}
+
+    mkdir -p ${dir}-build
+    pushd ${dir}-build
+    cmake ../${dir} -DOPENSSL_ROOT_DIR=/opt/vagrant/embedded/
+    make
+    sudo cp lib/libssh* /opt/vagrant/embedded/lib64
+    popd
+}
+
+function build_krb5() {
+    local dir=${1}
+
+    pushd ${dir}/src
+    ./configure
+    make
+    sudo cp -P lib/crypto/libk5crypto.* /opt/vagrant/embedded/lib64/
+    popd
+}
+
+function setup_rpm_sources_centos() {
+    typeset -n basedir=$1
+    pkg="$2"
+    rpmname="${3:-${pkg}}"
+
+    [[ ! -d ${pkg} ]] && git clone https://git.centos.org/rpms/${pkg}
+    cd ${pkg}
+    nvr=$(rpm -q --queryformat "${pkg}-%{version}-%{release}" ${rpmname})
+    nv=$(rpm -q --queryformat "${pkg}-%{version}" ${rpmname})
+    git checkout $(git tag -l | grep "${nvr}\$" | tail -n1)
+    into_srpm.sh -d c8s
+    cd BUILD
+    tar xf ../SOURCES/${nv}.tar.*z
+
+    basedir=${nv}
+}
+
+function patch_vagrant_centos_8() {
+    mkdir -p patches
+    pushd patches
+    [[ ! -d centos-git-common ]] && git clone https://git.centos.org/centos-git-common
+    export PATH=$(readlink -f ./centos-git-common):$PATH
+
+    setup_rpm_sources_centos LIBSSH_DIR libssh
+    build_libssh ${LIBSSH_DIR}
+
+    setup_rpm_sources_centos KRB5_DIR krb5 krb5-libs
+    build_krb5 ${KRB5_DIR}
+
+    popd
+}
+
+function setup_rpm_sources_fedora() {
+    typeset -n basedir=$1
+    pkg="$2"
+    rpmname="${3:-${pkg}}"
+
+    nvr=$(rpm -q --queryformat "${pkg}-%{version}-%{release}" ${rpmname})
+    nv=$(rpm -q --queryformat "${pkg}-%{version}" ${rpmname})
+    mkdir -p ${pkg}
+    cd ${pkg}
+
+    [[ ! -e ${nvr}.src.rpm ]] && dnf download --source ${rpmname}
+    rpm2cpio ${nvr}.src.rpm | cpio -imdV
+    rm -rf ${nv}
+    tar xf ${nv}.tar.*z
+
+    basedir=${nv}
+}
+
+function patch_vagrant_fedora() {
+    mkdir -p patches
+    pushd patches
+
+    setup_rpm_sources_fedora LIBSSH_DIR libssh
+    build_libssh ${LIBSSH_DIR}
+
+    setup_rpm_sources_fedora KRB5_DIR krb5 krb5-libs
+    build_krb5 ${KRB5_DIR}
+
+    popd
+}
+
+function install_vagrant() {
+    local version=${1}
+    local distro=${2}
+    local distro_version=${3:-}
+
+    eval install_vagrant_${distro} ${version}
+
+    if [[ -n "${distro_version}" ]] && [[ $(type -t patch_vagrant_${distro}_${distro_version} 2>/dev/null) == 'function' ]]
+    then
+        echo "running patch_vagrant_${distro}_${distro_version}"
+        eval patch_vagrant_${distro}_${distro_version}
+    elif [[ $(type -t patch_vagrant_${distro} 2>/dev/null) == 'function' ]]
+    then
+        echo "running patch_vagrant_${distro}"
+        eval patch_vagrant_${distro}
+    else
+        echo "no patch functions configured for ${distro} ${distro_version}"
+    fi
+}
+
+function install_vagrant_libvirt() {
+    if [[ "${VAGRANT_LIBVIRT_VERSION}" == "master" ]]
+    then
+        rm -rf build
+        mkdir build
+        git clone https://github.com/vagrant-libvirt/vagrant-libvirt.git
+        cd vagrant-libvirt
+        bundle install
+        bundle exec rake build
+        vagrant plugin install ./pkg/vagrant-libvirt-*.gem
+        cd -
+    elif [[ "${VAGRANT_LIBVIRT_VERSION}" == "latest" ]]
+    then
+        vagrant plugin install vagrant-libvirt
+    else
+        vagrant plugin install vagrant-libvirt --plugin-version ${VAGRANT_LIBVIRT_VERSION}
+    fi
+}
+
+
+VAGRANT_VERSION=$1
+DISTRO=${DISTRO:-$(awk -F= '/^ID=/{print $2}' /etc/os-release | tr -d '"' | tr '[A-Z]' '[a-z]')}
+DISTRO_VERSION=${DISTRO_VERSION:-$(awk -F= '/^VERSION_ID/{print $2}' /etc/os-release | tr -d '"' | tr '[A-Z]' '[a-z]' | tr -d '.')}
+
+setup_distro ${DISTRO} ${DISTRO_VERSION}
+
+install_vagrant ${VAGRANT_VERSION} ${DISTRO} ${DISTRO_VERSION}
+
+install_vagrant_libvirt


### PR DESCRIPTION
Provide a single script that is capable of performing the required
install steps needed to test various distros. This can be used by other
users in the future to simplify the steps required to have a successful
deployment.

Migrate the Vagrantfile used to be managed outside and uploaded as a
direct file, as that facilitates checking directly that the provided
config is valid.
