### PR TITLE
Support machine bring up without deploying vagrant-libvirt

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ Vagrant.configure(2) do |config|
         [].concat(
           settings.fetch(:docker, {}).fetch(:provision, [])
         ).concat(
-          settings.fetch(:provision, DEFAULT_PROVISION)
+          ENV.fetch('VAGRANT_LIBVIRT_DEPLOY', 'true') == 'true' ? settings.fetch(:provision, DEFAULT_PROVISION) : []
         ).concat(
           settings.fetch(:docker, {}).fetch(:post_install, [])
         ).each do |p|
@@ -80,12 +80,12 @@ Vagrant.configure(2) do |config|
         [].concat(
           settings.fetch(:libvirt, {}).fetch(:provision, [])
         ).concat(
-          settings.fetch(:provision, DEFAULT_PROVISION)
+          ENV.fetch('VAGRANT_LIBVIRT_DEPLOY', 'true') == 'true' ? settings.fetch(:provision, DEFAULT_PROVISION) : []
         ).each do |p|
           override.vm.provision :shell, **p
         end
 
-        add_test_provisions(override.vm)
+        add_test_provisions(override.vm) if ENV.fetch('VAGRANT_LIBVIRT_DEPLOY', 'true') == 'true'
       end
     end
   end

--- a/boxes.rb
+++ b/boxes.rb
@@ -35,6 +35,9 @@ BOXES = {
   'ubuntu-20.04' => {
     :libvirt => {
       :box => "generic/ubuntu2004",
+      :provision => [
+        {:inline => 'ln -sf ../run/systemd/resolve/resolv.conf /etc/resolv.conf'},
+      ],
     },
   },
   'debian-10' => {


### PR DESCRIPTION
To facilitate testing of installation issues from scratch, facilitate
bring up of the various machines including any required fixes for the
machine without execution of the installation script for
vagrant-libvirt.
