### PR TITLE
Retrieve latest vagrant version if not specified

### DIFF
--- a/.github/workflows/distro-install.yml
+++ b/.github/workflows/distro-install.yml
@@ -40,7 +40,7 @@ jobs:
         echo "QA_VAGRANT_LIBVIRT_VERSION=git-$(git submodule status -- vagrant-libvirt | cut -d' ' -f2)" >> ${GITHUB_ENV}
     - name: Set up libvirt
       run: |
-        ./scripts/install.bash --vagrant-only -- 2.2.19
+        ./scripts/install.bash --vagrant-only
     - uses: actions/cache@v3.0.4
       with:
         path: ~/.vagrant.d/boxes

--- a/boxes.rb
+++ b/boxes.rb
@@ -1,18 +1,5 @@
 #!/usr/bin/ruby
 #
-# Allow for passing test versions with env vars
-if ENV['QA_VAGRANT_VERSION'].nil? || ENV['QA_VAGRANT_VERSION'] == "latest"
-  # If not specified, fetch the latest version using built-in 'version' plugin
-  #
-  # NOTE: we 'cd /tmp' to avoid invoking Vagrant against this very Vagrantfile but
-  # that may not always work. There is probably a better way by leveraging
-  # VagrantPlugins::CommandVersion::Command and using 'version-latest'
-  # 
-  latest = `cd /tmp; vagrant version | grep Latest | awk '{ print $3 }'`
-  QA_VAGRANT_VERSION = latest.strip
-else
-  QA_VAGRANT_VERSION = ENV['QA_VAGRANT_VERSION']
-end
 
 APT_ENV_VARS = {
   'DEBIAN_FRONTEND': 'noninteractive',
@@ -83,7 +70,7 @@ BOXES = {
 }
 
 DEFAULT_PROVISION = [
-  {:name => 'install script', :privileged => false, :path => './scripts/install.bash', :args => "--vagrant-version #{QA_VAGRANT_VERSION}", :env => INSTALL_ENV_VARS},
+  {:name => 'install script', :privileged => false, :path => './scripts/install.bash', :args => ENV['QA_VAGRANT_VERSION'].nil? ? "" : "--vagrant-version #{ENV['QA_VAGRANT_VERSION']}", :env => INSTALL_ENV_VARS},
   {:name => 'setup group', :reset => true, :inline => 'usermod -a -G libvirt vagrant'},
   {:name => 'debug system capabilities', :privileged => false, :inline => 'virsh --connect qemu:///system capabilities'},
   {:name => 'debug uri', :privileged => false, :inline => 'virsh uri'},

--- a/scripts/install.bash
+++ b/scripts/install.bash
@@ -411,13 +411,11 @@ done
 
 if [[ -z ${VAGRANT_VERSION+x} ]]
 then
-    if [[ $# -ne 1 ]]
-    then
-        echo "$0: must specify the version of vagrant to install."
-        exit 4
-    fi
-
-    VAGRANT_VERSION=$1
+    VAGRANT_VERSION="$(
+        curl -sSLf https://checkpoint-api.hashicorp.com/v1/check/vagrant | \
+            tr ',' '\n' | grep current_version | cut -d: -f2 | tr -d '"'
+        )"
+    echo "Installing vagrant version '${VAGRANT_VERSION}'"
 fi
 
 echo "Starting vagrant-libvirt installation script"


### PR DESCRIPTION
Identify the latest vagrant version available without needing vagrant
installed by querying hashicorp's provided remote API for the current
version the tool available.
