### PR TITLE
Add recent distro releases

### DIFF
--- a/boxes.rb
+++ b/boxes.rb
@@ -27,9 +27,27 @@ BOXES = {
       ],
     },
   },
+  'ubuntu-22.04' => {
+    :libvirt => {
+      :box => "generic/ubuntu2204",
+      :provision => [
+        {:inline => 'ln -sf ../run/systemd/resolve/resolv.conf /etc/resolv.conf'},
+      ],
+    },
+  },
   'debian-10' => {
     :libvirt => {
       :box => "generic/debian10",
+      :provision => [
+        {:name => 'disable dns-nameservers', :inline => 'sed -i -e "/^dns-nameserver/g" /etc/network/interfaces', :reboot => true},
+        # restarting dnsmasq can require a retry after everything else to come up correctly.
+        {:name => 'install dnsmasq', :inline => 'apt update && apt install -y dnsmasq && systemctl restart dnsmasq', :env => APT_ENV_VARS},
+      ],
+    },
+  },
+  'debian-11' => {
+    :libvirt => {
+      :box => "generic/debian11",
       :provision => [
         {:name => 'disable dns-nameservers', :inline => 'sed -i -e "/^dns-nameserver/g" /etc/network/interfaces', :reboot => true},
         # restarting dnsmasq can require a retry after everything else to come up correctly.
@@ -57,11 +75,6 @@ BOXES = {
       :box => "generic/centos9s",
     },
   },
-  'fedora-33' => {
-    :libvirt => {
-      :box => "generic/fedora33",
-    },
-  },
   'fedora-34' => {
     :libvirt => {
       :box => "generic/fedora34",
@@ -70,6 +83,11 @@ BOXES = {
   'fedora-35' => {
     :libvirt => {
       :box => "generic/fedora35",
+    },
+  },
+  'fedora-36' => {
+    :libvirt => {
+      :box => "generic/fedora36",
     },
   },
   'archlinux' => {

--- a/docker/debian-11/Dockerfile
+++ b/docker/debian-11/Dockerfile
@@ -1,15 +1,15 @@
-FROM fedora:33
+FROM debian:11
 
 SHELL ["/bin/bash", "-c"]
 
-RUN dnf update -y && \
-    dnf install -y \
+RUN apt update \
+    && apt install -y \
         kmod \
-        openssh-clients \
         openssh-server \
-        sudo \
+        openssh-client \
         systemd \
-    && dnf clean all \
+        sudo \
+    && rm -rf /var/lib/apt/lists \
     ;
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ "$i" == "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
@@ -21,14 +21,13 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ "$i" == "sys
     rm -f /lib/systemd/system/basic.target.wants/*;\
     rm -f /lib/systemd/system/anaconda.target.wants/*;
 
-RUN systemctl enable sshd \
-    && ln -s /usr/lib/systemd/system/systemd-user-sessions.service /etc/systemd/system/multi-user.target.wants/systemd-user-sessions.service \
+RUN systemctl enable ssh \
+    && ln -s /lib/systemd/system/systemd-user-sessions.service /etc/systemd/system/multi-user.target.wants/systemd-user-sessions.service \
     ;
 
 RUN set -e \
-    && cd /etc/ssh/ \
-    && ssh-keygen -A \
     && sed -i -e 's/Defaults.*requiretty/#&/' /etc/sudoers \
+    && sed -i -ne 'p; s/^deb /deb-src /p' /etc/apt/sources.list \
     ;
 
 RUN set -e \
@@ -48,4 +47,5 @@ RUN set -e \
 
 
 EXPOSE 22
-CMD ["/usr/sbin/init"]
+CMD ["/sbin/init"]
+

--- a/docker/fedora-36/Dockerfile
+++ b/docker/fedora-36/Dockerfile
@@ -1,0 +1,52 @@
+FROM fedora:36
+
+SHELL ["/bin/bash", "-c"]
+
+RUN dnf update -y && \
+    dnf install -y \
+        dnf-plugins-core \
+        kmod \
+        openssh-clients \
+        openssh-server \
+        sudo \
+        systemd \
+    && dnf clean all \
+    ;
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ "$i" == "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;\
+    rm -f /etc/systemd/system/*.wants/*;\
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;\
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+RUN systemctl enable sshd \
+    && ln -s /usr/lib/systemd/system/systemd-user-sessions.service /etc/systemd/system/multi-user.target.wants/systemd-user-sessions.service \
+    ;
+
+RUN set -e \
+    && cd /etc/ssh/ \
+    && ssh-keygen -A \
+    && sed -i -e 's/Defaults.*requiretty/#&/' /etc/sudoers \
+    ;
+
+RUN set -e \
+    && useradd --create-home -s /bin/bash vagrant \
+    && echo -n 'vagrant:vagrant' | chpasswd \
+    && echo 'vagrant ALL = NOPASSWD: ALL' > /etc/sudoers.d/vagrant \
+    && chmod 440 /etc/sudoers.d/vagrant \
+    ;
+
+RUN set -e \
+    && mkdir -p /home/vagrant/.ssh \
+    && chmod 700 /home/vagrant/.ssh \
+    && echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ==" > /home/vagrant/.ssh/authorized_keys \
+    && chmod 600 /home/vagrant/.ssh/authorized_keys \
+    && chown -R vagrant:vagrant /home/vagrant/.ssh \
+    ;
+
+
+EXPOSE 22
+CMD ["/usr/sbin/init"]

--- a/docker/ubuntu-22.04/Dockerfile
+++ b/docker/ubuntu-22.04/Dockerfile
@@ -1,0 +1,52 @@
+FROM ubuntu:22.04
+
+SHELL ["/bin/bash", "-c"]
+
+# undo the minimizing done by upstream as expect to login to the resulting container
+RUN yes | unminimize
+
+RUN apt update \
+    && apt install -y \
+        kmod \
+        openssh-server \
+        openssh-client \
+        systemd \
+        sudo \
+    && rm -rf /var/lib/apt/lists \
+    ;
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ "$i" == "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;\
+    rm -f /etc/systemd/system/*.wants/*;\
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;\
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+RUN systemctl enable ssh \
+    && ln -s /lib/systemd/system/systemd-user-sessions.service /etc/systemd/system/multi-user.target.wants/systemd-user-sessions.service \
+    ;
+
+RUN set -e \
+    && sed -i -e 's/Defaults.*requiretty/#&/' /etc/sudoers \
+    ;
+
+RUN set -e \
+    && useradd --create-home -s /bin/bash vagrant \
+    && echo -n 'vagrant:vagrant' | chpasswd \
+    && echo 'vagrant ALL = NOPASSWD: ALL' > /etc/sudoers.d/vagrant \
+    && chmod 440 /etc/sudoers.d/vagrant \
+    ;
+
+RUN set -e \
+    && mkdir -p /home/vagrant/.ssh \
+    && chmod 700 /home/vagrant/.ssh \
+    && echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ==" > /home/vagrant/.ssh/authorized_keys \
+    && chmod 600 /home/vagrant/.ssh/authorized_keys \
+    && chown -R vagrant:vagrant /home/vagrant/.ssh \
+    ;
+
+
+EXPOSE 22
+CMD ["/sbin/init"]


### PR DESCRIPTION
Include recent releases such as Fedora 36, Debian 11, and Ubuntu 22.04
so that the most recent distro releases are all being tested.
