### PR TITLE
Ensure docker image of archlinux updated

### DIFF
--- a/docker/archlinux/Dockerfile
+++ b/docker/archlinux/Dockerfile
@@ -2,7 +2,7 @@ FROM archlinux:base
 
 SHELL ["/bin/bash", "-c"]
 
-RUN pacman -Sy --noconfirm --noprogressbar \
+RUN pacman -Syu --noconfirm --noprogressbar \
     && pacman -S --needed --noprogressbar --noconfirm \
         kmod \
         polkit \


### PR DESCRIPTION
To handle updates to some core libraries ensure that the system is fully
up to date before attempting to install new packages.
