### PR TITLE
Remove busybox-gzip before installing libvirt for openSUSE

### DIFF
--- a/scripts/install.bash
+++ b/scripts/install.bash
@@ -191,6 +191,11 @@ function setup_opensuse-leap() {
     # for package details to download the src.rpm's.
     sudo zypper modifyrepo --enable repo-source
     sudo zypper refresh
+    # blocks install of libvirt qemu system package
+    if rpm -q busybox-gzip 2>/dev/null 2>&1
+    then
+        sudo zypper remove --no-confirm busybox-gzip
+    fi
     sudo zypper install --no-confirm \
         byacc \
         cmake \


### PR DESCRIPTION
Remove the busybox-gzip package to allow libvirt and dependencies to be
installed without requiring input
